### PR TITLE
test: exec a submodule that yields back to parent

### DIFF
--- a/integration-tests/src/tests/runtime/submodule.rs
+++ b/integration-tests/src/tests/runtime/submodule.rs
@@ -102,3 +102,84 @@ fn submodule_return_int_no_resume() -> Vec<u8> {
     )
     .expect("The submodule should be valid wat")
 }
+
+#[test]
+fn test_submodule_execution_with_one_resume() {
+    let wasm_binary = near_test_contracts::rs_contract();
+    let node = setup_runtime_node_with_contract(test_contract_account(), wasm_binary);
+
+    let submodule_key = b"submodule1".to_vec();
+    let submodule_code = submodule_yield_and_return_int();
+
+    // Deploy submodule.
+    let tx_result = node
+        .user()
+        .deploy_submodule(test_contract_account(), submodule_key.clone(), submodule_code.clone())
+        .expect("Transaction that deploys submodule should succeed");
+    assert_eq!(tx_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
+
+    let tx_result = node
+        .user()
+        .function_call(
+            alice_account(),
+            test_contract_account(),
+            "execute_submodule_with_one_resume",
+            submodule_key,
+            MAX_GAS,
+            0,
+        )
+        .expect("Transaction that executes submodule should succeed");
+
+    let mut expected_bytes = vec![];
+    expected_bytes.extend(42u64.to_le_bytes()); // data the submodule should yield back
+    expected_bytes.extend(43u64.to_le_bytes()); // data the submodule should return
+    assert_eq!(tx_result.status, FinalExecutionStatus::SuccessValue(expected_bytes));
+}
+
+/// Returns the WebAssembly binary of a submodule that:
+///
+/// 1) Yields back to the main contract once passing back `42u64`.
+/// 2) After resume it completes execution and returns `43u64`.
+fn submodule_yield_and_return_int() -> Vec<u8> {
+    wat::parse_str(
+        r#"
+            (module
+                (type $t_env_callback (func (param i64 i64)))
+                (type $t_env_return_value (func (param i64 i64)))
+                (type $t_main (func))
+
+                (import "env" "callback" (func $env.callback (type $t_env_callback)))
+                (import "env" "return_value" (func $env.return_value (type $t_env_return_value)))
+
+                (memory 1)
+
+                (func $main (export "main") (type $t_main)
+                    ;; Store bytes to be passed to `callback` in memory at address 0.
+                    (i64.store
+                        (i32.const 0)
+                        (i64.const 42))
+
+                    ;; Yield to the main contract. The length is 8 since we return an `i64`. The
+                    ;; address 0 was used above to store the data to pass to the main contract.
+                    (call $env.callback
+                        (i64.const 8)
+                        (i64.extend_i32_u
+                            (i32.const 0)))
+
+                    ;; Store bytes passed to `return_value` in memory at address 8 (after the bytes
+                    ;; stored above).
+                    (i64.store
+                        (i32.const 8)
+                        (i64.const 43))
+
+                    ;; Return the bytes stored above. The length is 8 since we return an `i64`.
+                    (call $env.return_value
+                        (i64.const 8)
+                        (i64.extend_i32_u
+                            (i32.const 8)))
+                    )
+            )
+        "#,
+    )
+    .expect("The submodule should be valid wat")
+}

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -1295,8 +1295,7 @@ pub unsafe fn execute_submodule_no_resume() {
 
     // Retrieve key from input.
     input(input_register);
-    let key = vec![0; register_len(input_register) as usize];
-    read_register(input_register, key.as_ptr() as u64);
+    let key = get_register_data(input_register);
 
     // Start the submodule and assert it terminates (no callback).
     let submodule_exec_status = start_submodule(
@@ -1308,8 +1307,7 @@ pub unsafe fn execute_submodule_no_resume() {
     assert_eq!(submodule_exec_status, 0, "Submodule should not yield back to parent");
 
     // Return the value returned by the submodule.
-    let result = vec![0; register_len(submodule_output_register) as usize];
-    read_register(submodule_output_register, result.as_ptr() as u64);
+    let result = get_register_data(submodule_output_register);
     value_return(result.len() as u64, result.as_ptr() as u64);
 }
 


### PR DESCRIPTION
Adds an integration test which successfully executes a submodule that:

- Yields back to the parent contract once, passing data.
- Is resumed afterwards by the parent and then finsishes execution, returning data.

The test can be run with:

```
cargo test --package integration-tests --lib -- tests::runtime::submodule::test_submodule_execution_with_one_resume --exact --nocapture
```